### PR TITLE
feat: added admin call to update agency postcode ranges

### DIFF
--- a/api/agencyadminservice.yaml
+++ b/api/agencyadminservice.yaml
@@ -138,7 +138,7 @@ paths:
       parameters:
         - name: agencyId
           in: path
-          description: Agency Id
+          description: Agency ID
           required: true
           schema:
             type: integer
@@ -151,7 +151,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/AgencyAdminFullResponseDTO'
         204:
-          description: NO CONTENT - agency with the specific id was not found
+          description: NO CONTENT - agency with the provided ID does not exist
         400:
           description: BAD REQUEST - invalid/incomplete request
         401:
@@ -323,7 +323,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/AgencyPostcodeRangeResponseDTO'
         204:
-          description: NO CONTENT - agency postcode range with the specific id was not found
+          description: NO CONTENT - agency postcode range with the provided ID does not exist
         400:
           description: BAD REQUEST - invalid/incomplete request
         401:
@@ -352,8 +352,8 @@ paths:
             type: integer
             format: int64
       responses:
-        201:
-          description: CREATED - agency postcode range was created successfully
+        200:
+          description: OK - agency postcode range was successfully updated
           content:
             'application/hal+json':
               schema:
@@ -362,6 +362,8 @@ paths:
           description: BAD REQUEST - invalid/incomplete request or body object
         401:
           description: UNAUTHORIZED - no/invalid role/authorization
+        404:
+          description: NOT FOUND - agency postcode range with the provided ID does not exist
         500:
           description: INTERNAL SERVER ERROR - server encountered unexpected condition
       security:
@@ -387,7 +389,7 @@ paths:
         401:
           description: UNAUTHORIZED - no/invalid role/authorization
         404:
-          description: NOT FOUND - agency postcode range with the specific id was not found
+          description: NOT FOUND - agency postcode range with the provided ID does not exist
         500:
           description: INTERNAL SERVER ERROR - server encountered unexpected condition
       security:

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminController.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminController.java
@@ -52,6 +52,23 @@ public class AgencyAdminController implements AgencyadminApi {
   }
 
   /**
+   * Entry point to return all dioceses.
+   *
+   * @param page    Number of page where to start in the query (1 = first page) (required)
+   * @param perPage Number of items which are being returned per page (required)
+   * @return {@link DioceseAdminResultDTO}
+   */
+  @Override
+  public ResponseEntity<DioceseAdminResultDTO> getDioceses(
+      @NotNull @Valid Integer page, @NotNull @Valid Integer perPage) {
+
+    DioceseAdminResultDTO dioceseAdminResultDTO =
+        dioceseAdminService.findAllDioceses(page, perPage);
+
+    return new ResponseEntity<>(dioceseAdminResultDTO, HttpStatus.OK);
+  }
+
+  /**
    * Entry point to search for agencies.
    *
    * @param page    Number of page where to start in the query (1 = first page) (required)
@@ -67,23 +84,6 @@ public class AgencyAdminController implements AgencyadminApi {
         this.agencyAdminSearchService.searchAgencies(q, page, perPage);
 
     return new ResponseEntity<>(agencyAdminSearchResultDTO, HttpStatus.OK);
-  }
-
-  /**
-   * Entry point to return all dioceses.
-   *
-   * @param page    Number of page where to start in the query (1 = first page) (required)
-   * @param perPage Number of items which are being returned per page (required)
-   * @return {@link DioceseAdminResultDTO}
-   */
-  @Override
-  public ResponseEntity<DioceseAdminResultDTO> getDioceses(
-      @NotNull @Valid Integer page, @NotNull @Valid Integer perPage) {
-
-    DioceseAdminResultDTO dioceseAdminResultDTO =
-        dioceseAdminService.findAllDioceses(page, perPage);
-
-    return new ResponseEntity<>(dioceseAdminResultDTO, HttpStatus.OK);
   }
 
   /**
@@ -103,38 +103,6 @@ public class AgencyAdminController implements AgencyadminApi {
   }
 
   /**
-   * Entry point to get the postcode ranges for a specific agency.
-   *
-   * @param agencyId Agency Id (required)
-   * @param page     Number of page where to start (1 = first page) (required)
-   * @param perPage  Number of items which are being returned per page (required)
-   * @return an entity containing the search result
-   */
-  @Override
-  public ResponseEntity<AgencyPostcodeRangesResultDTO> getAgencyPostcodeRanges(
-      @PathVariable Long agencyId,
-      @NotNull @Valid Integer page, @NotNull @Valid Integer perPage) {
-    AgencyPostcodeRangesResultDTO postCodeRangesForAgency = this.agencyPostCodeRangeAdminService
-        .findPostCodeRangesForAgency(page, perPage, agencyId);
-    return ResponseEntity.ok(postCodeRangesForAgency);
-  }
-
-  /**
-   * Entry point to create a new postcode range for the given agency.
-   *
-   * @param agencyId         Agency Id (required)
-   * @param postCodeRangeDTO {@link PostCodeRangeDTO} (required)
-   * @return an entity containing the created postcode ranges
-   */
-  @Override public ResponseEntity<AgencyPostcodeRangeResponseDTO> createAgencyPostcodeRange(
-      @PathVariable Long agencyId, @Valid PostCodeRangeDTO postCodeRangeDTO) {
-
-    return new ResponseEntity<>(
-        agencyPostCodeRangeAdminService.createPostcodeRange(agencyId, postCodeRangeDTO),
-        HttpStatus.CREATED);
-  }
-
-  /**
    * Entry point to update a specific agency.
    *
    * @param agencyId        Agency Id (required)
@@ -150,6 +118,53 @@ public class AgencyAdminController implements AgencyadminApi {
         .updateAgency(agencyId, updateAgencyDTO);
 
     return ResponseEntity.ok(agencyAdminFullResponseDTO);
+  }
+
+  /**
+   * Entry point to get the postcode ranges for a specific agency.
+   *
+   * @param agencyId Agency Id (required)
+   * @param page     Number of page where to start (1 = first page) (required)
+   * @param perPage  Number of items which are being returned per page (required)
+   * @return an entity containing the search result
+   */
+  @Override
+  public ResponseEntity<AgencyPostcodeRangesResultDTO> getAgencyPostcodeRanges(
+      @PathVariable Long agencyId,
+      @NotNull @Valid Integer page, @NotNull @Valid Integer perPage) {
+    AgencyPostcodeRangesResultDTO postCodeRangesForAgency = this.agencyPostCodeRangeAdminService
+        .findPostcodeRangesForAgency(page, perPage, agencyId);
+    return ResponseEntity.ok(postCodeRangesForAgency);
+  }
+
+  /**
+   * Entry point to create a new postcode range for the given agency.
+   *
+   * @param agencyId         Agency Id (required)
+   * @param postCodeRangeDTO {@link PostCodeRangeDTO} (required)
+   * @return an entity containing the created postcode range
+   */
+  @Override public ResponseEntity<AgencyPostcodeRangeResponseDTO> createAgencyPostcodeRange(
+      @PathVariable Long agencyId, @Valid PostCodeRangeDTO postCodeRangeDTO) {
+
+    return new ResponseEntity<>(
+        agencyPostCodeRangeAdminService.createPostcodeRange(agencyId, postCodeRangeDTO),
+        HttpStatus.CREATED);
+  }
+
+  /**
+   * Entry point to update a postcode range for the given postcode range Id.
+   *
+   * @param postcodeRangeId  Postcode range Id (required)
+   * @param postCodeRangeDTO {@link PostCodeRangeDTO} (required)
+   * @return an entity containing the updated postcode range
+   */
+  @Override public ResponseEntity<AgencyPostcodeRangeResponseDTO> updateAgencyPostcodeRange(
+      @PathVariable Long postcodeRangeId, @Valid PostCodeRangeDTO postCodeRangeDTO) {
+    AgencyPostcodeRangeResponseDTO rangeResponseDTO = agencyPostCodeRangeAdminService
+        .updatePostcodeRange(postcodeRangeId, postCodeRangeDTO);
+
+    return ResponseEntity.ok(rangeResponseDTO);
   }
 
   /**

--- a/src/main/java/de/caritas/cob/agencyservice/api/admin/service/agencypostcoderange/create/PostcodeRangeValidator.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/admin/service/agencypostcoderange/create/PostcodeRangeValidator.java
@@ -2,7 +2,6 @@ package de.caritas.cob.agencyservice.api.admin.service.agencypostcoderange.creat
 
 import de.caritas.cob.agencyservice.api.exception.httpresponses.InvalidPostcodeException;
 import de.caritas.cob.agencyservice.api.model.PostCodeRangeDTO;
-import de.caritas.cob.agencyservice.api.repository.agency.Agency;
 import de.caritas.cob.agencyservice.api.repository.agencypostcoderange.AgencyPostCodeRange;
 import java.util.List;
 import org.apache.commons.lang3.Range;
@@ -15,32 +14,18 @@ import org.springframework.stereotype.Component;
 public class PostcodeRangeValidator {
 
   /**
-   * Validates if the given postcode range is valid (postcodeFrom is smaller than postcodeTo).
+   * Validates if the given postcode range is valid (postcodeFrom is smaller than postcodeTo) and if
+   * the given postcode range already exists or intersects with the given {@link * Agency}'s data.
    *
    * @param postCodeRangeDTO {@link PostCodeRangeDTO}
    */
-  public void validatePostcodeRange(PostCodeRangeDTO postCodeRangeDTO) {
+  public void validatePostcodeRange(PostCodeRangeDTO postCodeRangeDTO,
+      List<AgencyPostCodeRange> postCodeRangeList) {
     if (isPostcodeFromBiggerThanPostcodeTo(postCodeRangeDTO)) {
       throw new InvalidPostcodeException();
     }
-  }
 
-  /**
-   * Validates if the given postcode range already exists or intersects with the given {@link
-   * Agency}'s data.
-   *
-   * @param postCodeRangeDTO  {@link PostCodeRangeDTO}
-   * @param postCodeRangeList a list of {@link AgencyPostCodeRange}
-   */
-  public void validatePostcodeRangeForAgency(PostCodeRangeDTO postCodeRangeDTO,
-      List<AgencyPostCodeRange> postCodeRangeList) {
-    Range<Integer> providedRange = Range
-        .between(Integer.valueOf(postCodeRangeDTO.getPostcodeFrom()),
-            Integer.valueOf(postCodeRangeDTO.getPostcodeTo()));
-
-    if (rangeOverlapsRangeList(postCodeRangeList, providedRange)) {
-      throw new InvalidPostcodeException();
-    }
+    validatePostcodeRangeForAgency(postCodeRangeDTO, postCodeRangeList);
   }
 
   private boolean isPostcodeFromBiggerThanPostcodeTo(PostCodeRangeDTO postCodeRangeDTO) {
@@ -48,6 +33,17 @@ public class PostcodeRangeValidator {
       return Integer.parseInt(postCodeRangeDTO.getPostcodeFrom()) > Integer
           .parseInt(postCodeRangeDTO.getPostcodeTo());
     } catch (NumberFormatException exception) {
+      throw new InvalidPostcodeException();
+    }
+  }
+
+  private void validatePostcodeRangeForAgency(PostCodeRangeDTO postCodeRangeDTO,
+      List<AgencyPostCodeRange> postCodeRangeList) {
+    Range<Integer> providedRange = Range
+        .between(Integer.valueOf(postCodeRangeDTO.getPostcodeFrom()),
+            Integer.valueOf(postCodeRangeDTO.getPostcodeTo()));
+
+    if (rangeOverlapsRangeList(postCodeRangeList, providedRange)) {
       throw new InvalidPostcodeException();
     }
   }

--- a/src/main/java/de/caritas/cob/agencyservice/api/repository/agencypostcoderange/AgencyPostCodeRangeRepository.java
+++ b/src/main/java/de/caritas/cob/agencyservice/api/repository/agencypostcoderange/AgencyPostCodeRangeRepository.java
@@ -25,5 +25,4 @@ public interface AgencyPostCodeRangeRepository extends CrudRepository<AgencyPost
    * @return the amount of postcode ranges
    */
   long countAllByAgencyId(Long agencyId);
-
 }

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerAuthorizationIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerAuthorizationIT.java
@@ -9,6 +9,7 @@ import static de.caritas.cob.agencyservice.api.admin.controller.AgencyAdminContr
 import static de.caritas.cob.agencyservice.api.admin.controller.AgencyAdminControllerTest.PAGE_PARAM;
 import static de.caritas.cob.agencyservice.api.admin.controller.AgencyAdminControllerTest.PER_PAGE_PARAM;
 import static de.caritas.cob.agencyservice.api.admin.controller.AgencyAdminControllerTest.UPDATE_AGENCY_PATH;
+import static de.caritas.cob.agencyservice.api.admin.controller.AgencyAdminControllerTest.UPDATE_AGENCY_POSTCODE_RANGE_PATH;
 import static de.caritas.cob.agencyservice.testHelper.TestConstants.VALID_AGENCY_DTO;
 import static de.caritas.cob.agencyservice.testHelper.TestConstants.VALID_AGENCY_UPDATE_DTO;
 import static de.caritas.cob.agencyservice.testHelper.TestConstants.VALID_POSTCODE_RANGE_DTO;
@@ -185,7 +186,7 @@ public class AgencyAdminControllerAuthorizationIT {
         .header(CSRF_HEADER, CSRF_VALUE))
         .andExpect(status().isOk());
 
-    verify(this.agencyPostCodeRangeAdminService, times(1)).findPostCodeRangesForAgency(anyInt(),
+    verify(this.agencyPostCodeRangeAdminService, times(1)).findPostcodeRangesForAgency(anyInt(),
         anyInt(), anyLong());
   }
 
@@ -350,5 +351,45 @@ public class AgencyAdminControllerAuthorizationIT {
 
     verify(this.agencyPostCodeRangeAdminService, times(1))
         .createPostcodeRange(Mockito.anyLong(), Mockito.any(PostCodeRangeDTO.class));
+  }
+
+  @Test
+  public void updateAgencyPostcodeRange_Should_ReturnForbiddenAndCallNoMethods_WhenNoCsrfTokens()
+      throws Exception {
+
+    mvc.perform(put(UPDATE_AGENCY_POSTCODE_RANGE_PATH)
+        .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isForbidden());
+
+    verifyNoMoreInteractions(this.agencyPostCodeRangeAdminService);
+  }
+
+  @Test
+  public void updateAgencyPostcodeRange_Should_ReturnUnauthorizedAndCallNoMethods_When_noKeycloakAuthorizationIsPresent()
+      throws Exception {
+
+    mvc.perform(put(UPDATE_AGENCY_POSTCODE_RANGE_PATH)
+        .contentType(MediaType.APPLICATION_JSON)
+        .cookie(CSRF_COOKIE)
+        .header(CSRF_HEADER, CSRF_VALUE))
+        .andExpect(status().isUnauthorized());
+
+    verifyNoMoreInteractions(this.agencyPostCodeRangeAdminService);
+  }
+
+  @Test
+  @WithMockUser(authorities = {"AUTHORIZATION_AGENCY_ADMIN"})
+  public void updateAgencyPostcodeRange_Should_ReturnOkAndCallAgencyPostCodeRangeAdminService_When_agencyAdminAuthority()
+      throws Exception {
+
+    mvc.perform(put(UPDATE_AGENCY_POSTCODE_RANGE_PATH)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(VALID_POSTCODE_RANGE_DTO)
+        .cookie(CSRF_COOKIE)
+        .header(CSRF_HEADER, CSRF_VALUE))
+        .andExpect(status().isOk());
+
+    verify(this.agencyPostCodeRangeAdminService, times(1))
+        .updatePostcodeRange(Mockito.anyLong(), Mockito.any(PostCodeRangeDTO.class));
   }
 }

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/controller/AgencyAdminControllerTest.java
@@ -2,6 +2,7 @@ package de.caritas.cob.agencyservice.api.admin.controller;
 
 import static de.caritas.cob.agencyservice.testHelper.TestConstants.AGENCY_ID;
 import static de.caritas.cob.agencyservice.testHelper.TestConstants.CONSULTING_TYPE_PREGNANCY;
+import static de.caritas.cob.agencyservice.testHelper.TestConstants.INVALID_POSTCODE;
 import static de.caritas.cob.agencyservice.testHelper.TestConstants.VALID_POSTCODE;
 import static de.caritas.cob.agencyservice.testHelper.TestConstants.VALID_POSTCODE_2;
 import static org.hamcrest.Matchers.endsWith;
@@ -63,6 +64,8 @@ public class AgencyAdminControllerTest {
       + "/postcoderange/";
   protected static final String CREATE_AGENCY_POSTCODE_RANGE_PATH = ROOT_PATH
       + "/agency/1/postcoderange";
+  protected static final String UPDATE_AGENCY_POSTCODE_RANGE_PATH = ROOT_PATH
+      + "/postcoderange/1";
 
   @Autowired
   private MockMvc mvc;
@@ -226,7 +229,7 @@ public class AgencyAdminControllerTest {
         .andExpect(status().isOk());
 
     Mockito.verify(this.agencyPostCodeRangeAdminService, Mockito.times(1))
-        .findPostCodeRangesForAgency(eq(0), eq(1), eq(1L));
+        .findPostcodeRangesForAgency(eq(0), eq(1), eq(1L));
   }
 
   @Test
@@ -340,7 +343,7 @@ public class AgencyAdminControllerTest {
   }
 
   @Test
-  public void createAgencyPostcodeRange_Should_returnCreated_When_requiredPaginationParamsAreGiven()
+  public void createAgencyPostcodeRange_Should_returnCreated_When_AllParamsAreValid()
       throws Exception {
     PostCodeRangeDTO postCodeRangeDTO = new PostCodeRangeDTO()
         .postcodeFrom(VALID_POSTCODE)
@@ -350,5 +353,44 @@ public class AgencyAdminControllerTest {
         .content(new ObjectMapper().writeValueAsString(postCodeRangeDTO))
         .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isCreated());
+  }
+
+  @Test
+  public void createAgencyPostcodeRange_Should_returnBadRequest_When_PostCodeIsInvalid()
+      throws Exception {
+    PostCodeRangeDTO postCodeRangeDTO = new PostCodeRangeDTO()
+        .postcodeFrom(INVALID_POSTCODE)
+        .postcodeTo(VALID_POSTCODE_2);
+
+    this.mvc.perform(post(CREATE_AGENCY_POSTCODE_RANGE_PATH)
+        .content(new ObjectMapper().writeValueAsString(postCodeRangeDTO))
+        .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  public void updateAgencyPostcodeRange_Should_returnOk_When_AllParamsAreValid()
+      throws Exception {
+    PostCodeRangeDTO postCodeRangeDTO = new PostCodeRangeDTO()
+        .postcodeFrom(VALID_POSTCODE)
+        .postcodeTo(VALID_POSTCODE_2);
+
+    this.mvc.perform(put(UPDATE_AGENCY_POSTCODE_RANGE_PATH)
+        .content(new ObjectMapper().writeValueAsString(postCodeRangeDTO))
+        .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  public void updateAgencyPostcodeRange_Should_returnBadRequest_When_PostCodeIsInvalid()
+      throws Exception {
+    PostCodeRangeDTO postCodeRangeDTO = new PostCodeRangeDTO()
+        .postcodeFrom(INVALID_POSTCODE)
+        .postcodeTo(VALID_POSTCODE_2);
+
+    this.mvc.perform(put(UPDATE_AGENCY_POSTCODE_RANGE_PATH)
+        .content(new ObjectMapper().writeValueAsString(postCodeRangeDTO))
+        .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
   }
 }

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencypostcoderange/AgencyPostCodeRangeAdminServiceIT.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencypostcoderange/AgencyPostCodeRangeAdminServiceIT.java
@@ -38,7 +38,7 @@ public class AgencyPostCodeRangeAdminServiceIT {
   @Test
   public void findPostCodeRangesForAgency_Should_returnOneResult_When_perPageIsSetToOne() {
     List<AgencyPostcodeRangeResponseDTO> postCodeRanges = this.agencyPostCodeRangeAdminService
-        .findPostCodeRangesForAgency(0, 1, 0L)
+        .findPostcodeRangesForAgency(0, 1, 0L)
         .getEmbedded();
 
     assertThat(postCodeRanges, hasSize(1));
@@ -47,7 +47,7 @@ public class AgencyPostCodeRangeAdminServiceIT {
   @Test
   public void findPostCodeRangesForAgency_Should_returnExpectedResult_When_perPageIsSetToOne() {
     PostCodeRangeResponseDTO postCodeRange = this.agencyPostCodeRangeAdminService
-        .findPostCodeRangesForAgency(0, 1, 0L)
+        .findPostcodeRangesForAgency(0, 1, 0L)
         .getEmbedded()
         .iterator()
         .next()
@@ -65,7 +65,7 @@ public class AgencyPostCodeRangeAdminServiceIT {
   @Test
   public void findPostCodeRangesForAgency_Should_returnOneResult_When_pageIsSetToOneAndPerPageIsSetToOne() {
     List<AgencyPostcodeRangeResponseDTO> postCodeRanges = this.agencyPostCodeRangeAdminService
-        .findPostCodeRangesForAgency(1, 1, 15L)
+        .findPostcodeRangesForAgency(1, 1, 15L)
         .getEmbedded();
 
     assertThat(postCodeRanges, hasSize(1));
@@ -74,7 +74,7 @@ public class AgencyPostCodeRangeAdminServiceIT {
   @Test
   public void findPostCodeRangesForAgency_Should_returnOneResult_When_paginationParamsAreZero() {
     List<AgencyPostcodeRangeResponseDTO> postCodeRanges = this.agencyPostCodeRangeAdminService
-        .findPostCodeRangesForAgency(0, 0, 0L)
+        .findPostcodeRangesForAgency(0, 0, 0L)
         .getEmbedded();
 
     assertThat(postCodeRanges, hasSize(1));
@@ -83,7 +83,7 @@ public class AgencyPostCodeRangeAdminServiceIT {
   @Test
   public void findPostCodeRangesForAgency_Should_returnOneResult_When_paginationParamsAreNegative() {
     List<AgencyPostcodeRangeResponseDTO> postCodeRanges = this.agencyPostCodeRangeAdminService
-        .findPostCodeRangesForAgency(-100, -10, 0L)
+        .findPostcodeRangesForAgency(-100, -10, 0L)
         .getEmbedded();
 
     assertThat(postCodeRanges, hasSize(1));
@@ -93,10 +93,10 @@ public class AgencyPostCodeRangeAdminServiceIT {
   @Test
   public void findPostCodeRangesForAgency_Should_returnPaginatedEntities_When_paginationParamsAreSplitted() {
     List<AgencyPostcodeRangeResponseDTO> firstPage = this.agencyPostCodeRangeAdminService
-        .findPostCodeRangesForAgency(1, 20, 15L)
+        .findPostcodeRangesForAgency(1, 20, 15L)
         .getEmbedded();
     List<AgencyPostcodeRangeResponseDTO> secondPage = this.agencyPostCodeRangeAdminService
-        .findPostCodeRangesForAgency(2, 20, 15L)
+        .findPostcodeRangesForAgency(2, 20, 15L)
         .getEmbedded();
 
     assertThat(firstPage, hasSize(20));
@@ -106,7 +106,7 @@ public class AgencyPostCodeRangeAdminServiceIT {
   @Test
   public void findPostCodeRangesForAgency_Should_haveExpectedLinks_When_AllParamsAreProvided() {
     PaginationLinks paginationLinks = this.agencyPostCodeRangeAdminService
-        .findPostCodeRangesForAgency(2, 2, 15L).getLinks();
+        .findPostcodeRangesForAgency(2, 2, 15L).getLinks();
 
     assertThat(paginationLinks.getSelf(), notNullValue());
     assertThat(paginationLinks.getSelf().getHref(),

--- a/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencypostcoderange/create/PostcodeRangeValidatorTest.java
+++ b/src/test/java/de/caritas/cob/agencyservice/api/admin/service/agencypostcoderange/create/PostcodeRangeValidatorTest.java
@@ -40,10 +40,11 @@ public class PostcodeRangeValidatorTest {
 
   @Test
   public void validatePostcodeRange_ShouldNot_ThrowException_WhenPostcodeFromIsSmallerThanPostcodeTo() {
-    PostCodeRangeDTO postCodeRangeDTO = new PostCodeRangeDTO().postcodeFrom(VALID_POSTCODE)
-        .postcodeTo(VALID_POSTCODE_2);
+    PostCodeRangeDTO postCodeRangeDTO = new PostCodeRangeDTO().postcodeFrom(VALID_POSTCODE_5)
+        .postcodeTo(VALID_POSTCODE_5);
 
-    this.postcodeRangeValidator.validatePostcodeRange(postCodeRangeDTO);
+    this.postcodeRangeValidator
+        .validatePostcodeRange(postCodeRangeDTO, this.agencyPostCodeRangeList);
   }
 
   @Test(expected = InvalidPostcodeException.class)
@@ -51,7 +52,8 @@ public class PostcodeRangeValidatorTest {
     PostCodeRangeDTO postCodeRangeDTO = new PostCodeRangeDTO().postcodeFrom(VALID_POSTCODE_2)
         .postcodeTo(VALID_POSTCODE);
 
-    this.postcodeRangeValidator.validatePostcodeRange(postCodeRangeDTO);
+    this.postcodeRangeValidator
+        .validatePostcodeRange(postCodeRangeDTO, this.agencyPostCodeRangeList);
   }
 
   @Test(expected = InvalidPostcodeException.class)
@@ -59,7 +61,8 @@ public class PostcodeRangeValidatorTest {
     PostCodeRangeDTO postCodeRangeDTO = new PostCodeRangeDTO().postcodeFrom(INVALID_POSTCODE)
         .postcodeTo(VALID_POSTCODE);
 
-    this.postcodeRangeValidator.validatePostcodeRange(postCodeRangeDTO);
+    this.postcodeRangeValidator
+        .validatePostcodeRange(postCodeRangeDTO, this.agencyPostCodeRangeList);
   }
 
   @Test(expected = InvalidPostcodeException.class)
@@ -67,24 +70,25 @@ public class PostcodeRangeValidatorTest {
     PostCodeRangeDTO postCodeRangeDTO = new PostCodeRangeDTO().postcodeFrom(VALID_POSTCODE)
         .postcodeTo(INVALID_POSTCODE);
 
-    this.postcodeRangeValidator.validatePostcodeRange(postCodeRangeDTO);
+    this.postcodeRangeValidator
+        .validatePostcodeRange(postCodeRangeDTO, this.agencyPostCodeRangeList);
   }
 
   @Test
-  public void validatePostcodeRangeForAgency_ShouldNot_ThrowException_WhenPostcodeIsNotWithinRangeList() {
+  public void validatePostcodeRange_ShouldNot_ThrowException_WhenPostcodeIsNotWithinRangeList() {
     PostCodeRangeDTO postCodeRangeDTO = new PostCodeRangeDTO().postcodeFrom(VALID_POSTCODE_5)
         .postcodeTo(VALID_POSTCODE_5);
 
     this.postcodeRangeValidator
-        .validatePostcodeRangeForAgency(postCodeRangeDTO, agencyPostCodeRangeList);
+        .validatePostcodeRange(postCodeRangeDTO, agencyPostCodeRangeList);
   }
 
   @Test(expected = InvalidPostcodeException.class)
-  public void validatePostcodeRangeForAgency_Should_ThrowInvalidPostcodeException_WhenPostcodeIsWithinRangeList() {
+  public void validatePostcodeRange_Should_ThrowInvalidPostcodeException_WhenPostcodeIsWithinRangeList() {
     PostCodeRangeDTO postCodeRangeDTO = new PostCodeRangeDTO().postcodeFrom(VALID_POSTCODE_6)
         .postcodeTo(VALID_POSTCODE_6);
 
     this.postcodeRangeValidator
-        .validatePostcodeRangeForAgency(postCodeRangeDTO, agencyPostCodeRangeList);
+        .validatePostcodeRange(postCodeRangeDTO, agencyPostCodeRangeList);
   }
 }


### PR DESCRIPTION
Added admin API call to update a postcode range of an agency.

    PUT /agencyadmin/postcoderange/{postcodeRangeId}
    Parameters:
        postcodeRangeId (required)
    Body:
        PostCodeRangeDTO (requried)